### PR TITLE
Swap comments for isFirstTime and isDelayComplete

### DIFF
--- a/GOTStateMachine.cpp
+++ b/GOTStateMachine.cpp
@@ -72,7 +72,7 @@ void GOTStateMachine::execute() {
   }
 }
 
-// Check if been in state longer that delayPeriod - specify in mS
+// Check if first time state is processed
 bool GOTStateMachine::isFirstTime() {
 
   if (!alreadyProcessed) {
@@ -82,7 +82,7 @@ bool GOTStateMachine::isFirstTime() {
   return false;
 }
 
-// Check if first time state is processed
+// Check if been in state longer that delayPeriod - specify in mS
 bool GOTStateMachine::isDelayComplete(unsigned long delayPeriod) {
 
   unsigned long loopTime = millis();


### PR DESCRIPTION
The descriptive comments for functions isFirstTime and isDelayComplete were swapped. Some IDEs (e.g. VS Code) show the comment line as description for intellisense, so it was confusing to have the mismatching comments.